### PR TITLE
Revert "Make sure to replace the used refresh token with a fresh one"

### DIFF
--- a/src/utils/spotify-api.utils.ts
+++ b/src/utils/spotify-api.utils.ts
@@ -54,7 +54,6 @@ export async function getUserSpotifyApi(
               settings: {
                 update: {
                   accessToken: refreshResult.body.access_token,
-                  refreshToken: refreshResult.body.refresh_token,
                   accessTokenExpiration: expirationDate,
                 },
               },


### PR DESCRIPTION
I forgot that the refresh token isnt updated on refresh. The Spotistats API makes use of the authorization code flow without pkce, and explained here: https://developer.spotify.com/documentation/general/guides/authorization-guide/#4-requesting-a-refreshed-access-token-spotify-returns-a-new-access-token-to-your-app the refresh accesstoken request does _not_ return a new refresh token.

tldr; refresh token doesn't change and can be used infinitely


ps. `refresh_token` doesn't even exist on the `RefreshAccessTokenResponse` interface:
```ts
interface RefreshAccessTokenResponse {
    access_token: string;
    expires_in: number;
    scope: string;
    token_type: string;
}
```